### PR TITLE
Add Circuit Playground Bluefruit Device Setup Guide

### DIFF
--- a/code/Level 2 - Intro to Programming/circup_libs_robotics.txt
+++ b/code/Level 2 - Intro to Programming/circup_libs_robotics.txt
@@ -1,0 +1,13 @@
+adafruit_lis3dh==5.2.2
+adafruit_thermistor==3.4.10
+neopixel==6.3.11
+adafruit_crickit==2.3.17
+adafruit_pixelbuf==2.0.4
+adafruit_ble==10.0.5
+adafruit_bluefruit_connect==1.2.13
+adafruit_bus_device==5.2.8
+adafruit_circuitplayground==5.3.4
+adafruit_gizmo==1.3.18
+adafruit_hid==6.0.3
+adafruit_motor==3.4.13
+adafruit_seesaw==1.16.2

--- a/site/content/exercises/circuitpython/robotics/index-summary.mdx
+++ b/site/content/exercises/circuitpython/robotics/index-summary.mdx
@@ -1,6 +1,10 @@
 ---
 order: 1
-title: CPX Robotics with CircuitPython
+title: Robotics with CircuitPython
 ---
 
-## Intro to CPX Robotics with CircuitPython
+## Intro to Robotics with CircuitPython
+
+Our curriculum for robotics with CircuitPython.
+
+### [Microcontroller Setup Instructions](http://opensource.morganstanley.com/cpx-training/exercises/circuitpython/setup_bluefruit/)

--- a/site/content/exercises/circuitpython/setup_bluefruit.mdx
+++ b/site/content/exercises/circuitpython/setup_bluefruit.mdx
@@ -1,0 +1,146 @@
+---
+order: 1
+title: Setup Circuit Playground Bluefruit
+---
+
+## Start Here
+
+A guide to setting up the Adafruit Circuit Playground Bluefruit for our curriculum.
+
+### What is the Circuit Playground BlueFruit?
+
+The Circuit Playgroud Bluefruit is very similar to the Circuit Playgroud Express, except it has Bluetooth Low Energy support instead of infrared (IR)!
+
+Adafruit also provides a free app on [iOS](https://apps.apple.com/us/app/bluefruit-connect/id830125974) and [Android](https://play.google.com/store/apps/details?id=com.adafruit.bluefruit.le.connect) to interface with the device over Bluetooth.
+
+### Checking the Bootloader
+
+[CircuitPython.org](https://circuitpython.org/) provides .uf2 files which make it easy to install CircuitPython on the device.  However,
+the Bluefruit devices may come with a much older bootloader.  For example, if you run this:
+
+```bash
+$ cat /media/pi/CPLAYBTBOOT/INFO_UF2.TXT
+UF2 Bootloader 0.2.9 lib/nrfx (v1.1.0-1-g096e770) lib/tinyusb (legacy-755-g55874813) s140 6.1.1
+Model: Adafruit Feather nRF52840 Express
+Board-ID: nRF52840-Feather-revD
+Bootloader: s140 6.1.1
+Date: Feb 22 2019
+```
+
+Note the UF2 bootloader is before version 0.4.0 which is the minimum version required to
+use the .uf2 files to install CircuitPython.  So let's update it.
+
+### Updating the Bootloader
+
+*Please note that this step is not required if the bootloader is 0.4.0 or more recent! (see above)*
+
+Find the latest bootloader .zip release [here](https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases) and download for the latest version, specifically a file named:
+`circuitplayground_nrf52840_bootloader-0.8.2_s140_6.1.1.zip` (or the latest version).
+
+To flash this to the device use `adafruit-nrfutil`.  You can install this via `pip3 install --user adafruit-nrfutil`.
+
+From there, you can update the firmware with the updated bootloader:
+
+```bash
+adafruit-nrfutil --verbose dfu serial --package /home/pi/Downloads/circuitplayground_nrf52840_bootloader-0.8.3_s140_6.1.1.zip \
+  -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
+````
+
+```
+Touched serial port /dev/ttyACM0
+Opened serial port /dev/ttyACM0
+Starting DFU upgrade of type 3, SoftDevice size: 151016, bootloader size: 39000, application size: 0
+Sending DFU start packet
+Sending DFU init packet
+Sending firmware file
+########################################
+Activating new firmware
+
+DFU upgrade took 20.90584897994995s
+Device programmed.
+```
+
+The 10 neopixels should show green and the CPLAYBTBOOT volume should be back.
+
+```bash
+$ cat /media/pi/CPLAYBTBOOT/INFO_UF2.TXT
+UF2 Bootloader 0.8.3 lib/nrfx (v2.0.0) lib/tinyusb (0.12.0-145-g9775e7691) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)
+```
+
+### Installing CircuitPython on the Device
+
+Now let's download the circuitpython UF2 file from the [CircuitPython Download Site for BlueFruit](https://circuitpython.org/board/circuitplayground_bluefruit/).
+
+You can drag OR copy to the volume as shown below:
+
+```bash
+$ cp adafruit-circuitpython-circuitplayground_bluefruit-en_US-8.2.9.uf2 /media/pi/CPLAYBTBOOT/
+```
+
+All 10 neopixels should go red and the red LED will pulse slightly.
+
+You should now see a `CIRCUITPY` drive, meaning we have CircuitPython installed!  Last thing we need to do it install the python libraries.
+These live here in circuitpython:
+
+```bash
+$ ls /media/pi/CIRCUITPY/lib
+(no output!)
+```
+
+To install libraries, we'll use an adafruit tool called `circup` which operates similar to python's pip, except for CircuitPython:
+
+```bash
+$ pip3 install --user circup
+```
+
+Let's download the list of required libraries from [here](https://github.com/morganstanley/cpx-training/blob/main/code/Level%202%20-%20Intro%20to%20Programming/circup_libs_robotics.txt).
+
+```
+$ circup install -r ~/Downloads/circup_libs_robotics_02_08_24.txt
+Found device at /media/pi/CIRCUITPY, running CircuitPython 8.2.9.
+Searching for dependencies for: ['adafruit_ble', 'adafruit_bluefruit_connect', 'adafruit_bus_device', 'adafruit_circuitplayground', 'adafruit_crickit', 'adafruit_gizmo', 'adafruit_hid', 'adafruit_lis3dh', 'adafruit_motor', 'adafruit_pixelbuf', 'adafruit_seesaw', 'adafruit_thermistor', 'found device at /media/pi/circuitpy, running circuitpython 8.2.9.', 'neopixel']
+WARNING:
+	found device at /media/pi/circuitpy, running circuitpython 8.2.9. is not a known CircuitPython library.
+WARNING:
+	typing-extensions is not a known CircuitPython library.
+WARNING:
+	typing-extensions is not a known CircuitPython library.
+Ready to install: ['adafruit_ble', 'adafruit_bluefruit_connect', 'adafruit_bus_device', 'adafruit_circuitplayground', 'adafruit_crickit', 'adafruit_gizmo', 'adafruit_hid', 'adafruit_il0373', 'adafruit_lis3dh', 'adafruit_motor', 'adafruit_pixelbuf', 'adafruit_seesaw', 'adafruit_ssd1681', 'adafruit_st7789', 'adafruit_thermistor', 'neopixel']
+
+Installed 'adafruit_ble'.
+Installed 'adafruit_bluefruit_connect'.
+Installed 'adafruit_bus_device'.
+Installed 'adafruit_circuitplayground'.
+Installed 'adafruit_crickit'.
+Installed 'adafruit_gizmo'.
+Installed 'adafruit_hid'.
+Installed 'adafruit_il0373'.
+Installed 'adafruit_lis3dh'.
+Installed 'adafruit_motor'.
+Installed 'adafruit_pixelbuf'.
+Installed 'adafruit_seesaw'.
+Installed 'adafruit_ssd1681'.
+Installed 'adafruit_st7789'.
+Installed 'adafruit_thermistor'.
+Installed 'neopixel'.
+```
+
+Now let's check out that directory:
+
+```bash
+$ ls /media/pi/CIRCUITPY/lib
+adafruit_ble               adafruit_crickit.mpy       adafruit_lis3dh.mpy        adafruit_ssd1681.mpy
+adafruit_bluefruit_connect adafruit_gizmo             adafruit_motor             adafruit_st7789.mpy
+adafruit_bus_device        adafruit_hid               adafruit_pixelbuf.mpy      adafruit_thermistor.mpy
+adafruit_circuitplayground adafruit_il0373.mpy        adafruit_seesaw            neopixel.mpy
+```
+
+Excellent! Our libraries are installed and we're ready to code.  You can follow this flow to install other
+CircuitPython libraries you may need when adding other components to the robot.
+
+
+### References:
+- [https://learn.adafruit.com/adafruit-circuit-playground-bluefruit/overview](https://learn.adafruit.com/adafruit-circuit-playground-bluefruit/overview)
+- [https://learn.adafruit.com/adafruit-circuit-playground-bluefruit/update-bootloader](https://learn.adafruit.com/adafruit-circuit-playground-bluefruit/update-bootloader)
+- [https://learn.adafruit.com/circuitpython-nrf52840/bluefruit-le-connect-basics](https://learn.adafruit.com/circuitpython-nrf52840/bluefruit-le-connect-basics)
+- [https://github.com/adafruit/circup](https://github.com/adafruit/circup)


### PR DESCRIPTION
To review directly: http://localhost:8000/exercises/circuitpython/setup_bluefruit/

Main entrypoint for students / instructors (top of curriculum page): http://localhost:8000/exercises/circuitpython/robotics/

Note that some links may be broken until this PR is merged, for example the above entrypoint, and `circup_libs_robotics.txt` which links directly to GitHub.

