### PR TITLE
Add link to updated lesson url, using relative path

### DIFF
--- a/site/content/exercises/makecode/robotics/E3/index.md
+++ b/site/content/exercises/makecode/robotics/E3/index.md
@@ -8,4 +8,4 @@ tags: ['Robotics', 'MakeCode']
 description: Let's dig into the details of using loops with the tempurature sensor!
 ---
 
-Refer to [This Lesson](https://opensource.morganstanley.com/cpx-training/exercises/makecode/E3/)
+Refer to [This Lesson](../../intro/E3/)


### PR DESCRIPTION
Closes #122 

Note that the relative path also fixes an issue wherein students who had been navigating the HTTP (vs HTTPS) version of the site received the SSL warning for the github SSL certificate for the first time.