### PR TITLE
Adding a simple link to the site/README.md so it's easier to find from the repo main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Makerspace Circuit Playground Express Training Workshops
 
-![Lifecycle Active](https://badgen.net/badge/Lifecycle/Active/green)  
+![Lifecycle Active](https://badgen.net/badge/Lifecycle/Active/green)
 
 This repository houses the materials that support the Morgan Stanley Makerspace [Circuit Playground Express](https://www.adafruit.com/product/3333) Workshops.
 
 [Learn more here](https://morgan-stanley.github.io/cpx-training/)
+
+## Contributing
+
+If you want to learn more on how to contribute (including how to preview your changes), you should read the [README](site/README.md)
 
 ## CPX Training Workshop
 


### PR DESCRIPTION
This is a simple tweak to allow contributors to find info faster