### PR TITLE
Add codeql-action grouping to github-actions dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       artifact-actions:
         patterns:
           - 'actions/*-artifact*' # Upload/Download usually need to be updated together
+      codeql-actions:
+        patterns:
+          - 'github/codeql-action/*'


### PR DESCRIPTION
Groups `github/codeql-action/*` updates together in the `github-actions` dependabot ecosystem so CodeQL action version bumps are batched into a single PR instead of one per component action.